### PR TITLE
feat(ecs): add and document the `Entity` struct

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,9 @@
     // this is here because Zig requires it.
     .version = "0.0.0",
 
-    .dependencies = .{},
+    .dependencies = .{
+        .ecs = .{ .path = "modules/ecs" },
+    },
 
     .paths = .{
         "src",

--- a/modules/ecs/build.zig
+++ b/modules/ecs/build.zig
@@ -5,24 +5,17 @@ pub fn build(b: *std.Build) void {
 
     const optimize = b.standardOptimizeOption(.{});
 
-    const mod = b.addModule("otter", .{
+    _ = b.addModule("ecs", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
-
-    const ecs_dep = b.dependency("ecs", .{ .target = target, .optimize = optimize });
-    const ecs_mod = ecs_dep.module("ecs");
-
-    mod.addImport("ecs", ecs_mod);
 
     const unit_tests = b.addTest(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
-
-    unit_tests.root_module.addImport("ecs", ecs_mod);
 
     const run_unit_tests = b.addRunArtifact(unit_tests);
 

--- a/modules/ecs/build.zig.zon
+++ b/modules/ecs/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = "ecs",
+
+    .version = "0.0.0",
+
+    .dependencies = .{},
+
+    .paths = .{
+        "src",
+        "build.zig",
+        "build.zig.zon",
+    },
+}

--- a/modules/ecs/src/identifier.zig
+++ b/modules/ecs/src/identifier.zig
@@ -1,0 +1,34 @@
+/// An `Entity` is any "thing" that exists in the world.
+///
+/// For most users of the ECS, this should be treated as an opaque identifier
+/// that shouldn't be modified.
+///
+/// Each `Entity` has an `id` and a `generation`.
+///
+/// The `Entity` struct is packed to ensure it gets treated the same
+/// as a `u64` in memory. This can increase performance on some platforms.
+pub const Entity = packed struct(u64) {
+    /// An `Entity` with an `id` of 0 is invalid,
+    /// regardless of the generation. This is used to make
+    /// it easy to check if an `Entity` is valid without optionals
+    /// that would use more memory.
+    // TODO: Use https://github.com/ziglang/zig/issues/3806 if/when it's
+    // implemented, as it could greatly enhance ergonomics here.
+    pub const invalid = Entity{ .id = 0 };
+
+    /// The unique `id` of the `Entity`. This is only unique on
+    /// a per-world basis.
+    id: u32,
+
+    /// The `generation` of the `Entity`. This is incremented
+    /// every time the `Entity` is re-used.
+    generation: u32 = 0,
+
+    /// Returns the same `Entity` but with the `generation` incremented.
+    pub fn nextGeneration(self: Entity) Entity {
+        return Entity{
+            .id = self.id,
+            .generation = self.generation + 1,
+        };
+    }
+};

--- a/modules/ecs/src/root.zig
+++ b/modules/ecs/src/root.zig
@@ -1,0 +1,3 @@
+pub const identifier = @import("identifier.zig");
+
+pub const Entity = identifier.Entity;

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,0 +1,1 @@
+pub const ecs = @import("ecs");


### PR DESCRIPTION
The `Entity` struct will represent practically anything in the world, and components will be
attachable to them. For this reason, we have to implement.